### PR TITLE
feat: auth — Better Auth, Google + Line OAuth, per-user data isolation (#21)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "better-auth": "^1.5.5",
         "dayjs": "^1.11.13",
         "drizzle-orm": "^0.45.1",
+        "elysia": "^1.4.27",
         "express": "^4.18.2",
         "openai": "^6.22.0",
         "ora": "^8.0.1",
@@ -474,6 +475,8 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
 
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
@@ -656,7 +659,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
@@ -712,6 +715,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.313", "", {}, "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA=="],
 
+    "elysia": ["elysia@1.4.27", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-2UlmNEjPJVA/WZVPYKy+KdsrfFwwNlqSBW1lHz6i2AHc75k7gV4Rhm01kFeotH7PDiHIX2G8X3KnRPc33SGVIg=="],
+
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
@@ -748,9 +753,13 @@
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
 
     "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -982,6 +991,8 @@
 
     "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
     "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
 
     "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
@@ -1031,6 +1042,8 @@
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "openai": ["openai@6.22.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["zod"], "bin": "bin/cli" }, "sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
@@ -1428,6 +1441,8 @@
 
     "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
@@ -1449,8 +1464,6 @@
     "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
-
-    "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@notionhq/client": "^2.2.15",
         "@opentui/core": "^0.1.81",
         "@opentui/react": "^0.1.81",
+        "better-auth": "^1.5.5",
         "dayjs": "^1.11.13",
         "drizzle-orm": "^0.45.1",
         "express": "^4.18.2",
@@ -219,6 +220,24 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
+    "@better-auth/core": ["@better-auth/core@1.5.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "better-call": "1.3.2", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA=="],
+
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "drizzle-orm": ">=0.41.0" }, "optionalPeers": ["drizzle-orm"] }, "sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw=="],
+
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "kysely": "^0.27.0 || ^0.28.0" } }, "sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g=="],
+
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0" } }, "sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "mongodb": "^6.0.0 || ^7.0.0" } }, "sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.5.5", "", { "peerDependencies": { "@better-auth/core": "1.5.5", "@better-auth/utils": "^0.3.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.5.5", "", { "dependencies": { "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21" }, "peerDependencies": { "@better-auth/core": "1.5.5" } }, "sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.3.1", "", {}, "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
@@ -381,9 +400,15 @@
 
     "@libsql/win32-x64-msvc": ["@libsql/win32-x64-msvc@0.5.22", "", { "os": "win32", "cpu": "x64" }, "sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA=="],
 
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.6", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
+
+    "@noble/ciphers": ["@noble/ciphers@2.1.1", "", {}, "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="],
+
+    "@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
 
     "@notionhq/client": ["@notionhq/client@2.3.0", "", { "dependencies": { "@types/node-fetch": "^2.5.10", "node-fetch": "^2.6.1" } }, "sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw=="],
 
@@ -448,6 +473,8 @@
     "@rollup/plugin-terser": ["@rollup/plugin-terser@0.4.4", "", { "dependencies": { "serialize-javascript": "^6.0.1", "smob": "^1.0.0", "terser": "^5.17.4" }, "peerDependencies": { "rollup": "^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
@@ -517,6 +544,10 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
@@ -565,6 +596,10 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.7", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw=="],
 
+    "better-auth": ["better-auth@1.5.5", "", { "dependencies": { "@better-auth/core": "1.5.5", "@better-auth/drizzle-adapter": "1.5.5", "@better-auth/kysely-adapter": "1.5.5", "@better-auth/memory-adapter": "1.5.5", "@better-auth/mongo-adapter": "1.5.5", "@better-auth/prisma-adapter": "1.5.5", "@better-auth/telemetry": "1.5.5", "@better-auth/utils": "0.3.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.2", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.11", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": ">=0.41.0", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg=="],
+
+    "better-call": ["better-call@1.3.2", "", { "dependencies": { "@better-auth/utils": "^0.3.1", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw=="],
+
     "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
     "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
@@ -572,6 +607,8 @@
     "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
@@ -650,6 +687,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -873,6 +912,8 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
     "js-base64": ["js-base64@3.7.8", "", {}, "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow=="],
@@ -892,6 +933,8 @@
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "kysely": ["kysely@0.28.12", "", {}, "sha512-kWiueDWXhbCchgiotwXkwdxZE/6h56IHAeFWg4euUfW0YsmO9sxbAxzx1KLLv2lox15EfuuxHQvgJ1qIfZuHGw=="],
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
@@ -939,6 +982,8 @@
 
     "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
     "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
 
     "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
@@ -955,9 +1000,15 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "mongodb": ["mongodb@7.1.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^7.1.1", "mongodb-connection-string-url": "^7.0.0" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.806.0", "@mongodb-js/zstd": "^7.0.0", "gcp-metadata": "^7.0.1", "kerberos": "^7.0.0", "mongodb-client-encryption": ">=7.0.0 <7.1.0", "snappy": "^7.3.2", "socks": "^2.8.6" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@7.0.1", "", { "dependencies": { "@types/whatwg-url": "^13.0.0", "whatwg-url": "^14.1.0" } }, "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nanostores": ["nanostores@1.1.1", "", {}, "sha512-EYJqS25r2iBeTtGQCHidXl1VfZ1jXM7Q04zXJOrMlxVVmD0ptxJaNux92n1mJ7c5lN3zTq12MhH/8x59nP+qmg=="],
 
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
@@ -1083,6 +1134,8 @@
 
     "rollup": ["rollup@2.80.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ=="],
 
+    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -1105,7 +1158,7 @@
 
     "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
 
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+    "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
@@ -1144,6 +1197,8 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
+
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
     "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
 
@@ -1307,13 +1362,45 @@
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@jimp/core/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "@jimp/plugin-blit/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-circle/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-color/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-contain/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-cover/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-crop/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-displace/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-fisheye/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-flip/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-mask/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-print/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-quantize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-resize/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-rotate/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/plugin-threshold/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@jimp/types/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@libsql/hrana-client/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
@@ -1353,6 +1440,8 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "mongodb-connection-string-url/whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
     "path-scurry/lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
     "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
@@ -1362,6 +1451,8 @@
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "react-router/set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.9", "", {}, "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw=="],
 
@@ -1450,6 +1541,10 @@
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "mongodb-connection-string-url/whatwg-url/tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "mongodb-connection-string-url/whatwg-url/webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@notionhq/client": "^2.2.15",
     "@opentui/core": "^0.1.81",
     "@opentui/react": "^0.1.81",
+    "better-auth": "^1.5.5",
     "dayjs": "^1.11.13",
     "drizzle-orm": "^0.45.1",
     "express": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "better-auth": "^1.5.5",
     "dayjs": "^1.11.13",
     "drizzle-orm": "^0.45.1",
+    "elysia": "^1.4.27",
     "express": "^4.18.2",
     "openai": "^6.22.0",
     "ora": "^8.0.1",

--- a/src/adapters/inbound/web/client/src/App.tsx
+++ b/src/adapters/inbound/web/client/src/App.tsx
@@ -1,14 +1,38 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useSession } from './features/auth/useSession';
+import { LoginPage } from './features/auth/LoginPage';
+
+function AppRoutes() {
+  const { loading, user } = useSession();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-950">
+        <div className="flex gap-1">
+          <span className="h-2 w-2 animate-bounce rounded-full bg-white/40" style={{ animationDelay: '0ms' }} />
+          <span className="h-2 w-2 animate-bounce rounded-full bg-white/40" style={{ animationDelay: '150ms' }} />
+          <span className="h-2 w-2 animate-bounce rounded-full bg-white/40" style={{ animationDelay: '300ms' }} />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) return <LoginPage />;
+
+  return (
+    <Routes>
+      <Route path="/" element={<div>Pax</div>} />
+      <Route path="/pomodoro" element={<div>Pomodoro (coming soon)</div>} />
+      <Route path="/tasks" element={<div>Tasks (coming soon)</div>} />
+      <Route path="*" element={<div>404</div>} />
+    </Routes>
+  );
+}
 
 export function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<div>Pax</div>} />
-        <Route path="/pomodoro" element={<div>Pomodoro (coming soon)</div>} />
-        <Route path="/tasks" element={<div>Tasks (coming soon)</div>} />
-        <Route path="*" element={<div>404</div>} />
-      </Routes>
+      <AppRoutes />
     </BrowserRouter>
   );
 }

--- a/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
+++ b/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
@@ -1,0 +1,41 @@
+interface OAuthButtonProps {
+  provider: 'google' | 'line';
+  /** For 'google': full href for anchor redirect. For 'line': onClick handler. */
+  href?: string;
+  onClick?: () => void;
+}
+
+export function OAuthButton({ provider, href, onClick }: OAuthButtonProps) {
+  const sharedClass =
+    'flex w-full items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 cursor-pointer';
+
+  if (provider === 'google') {
+    return (
+      <a
+        href={href}
+        className={`${sharedClass} border border-gray-200 bg-white text-gray-900 hover:bg-gray-100`}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" />
+          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+        </svg>
+        Continue with Google
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${sharedClass} bg-[#06C755] text-white hover:bg-[#05b34d]`}
+    >
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+        <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.627-.63.349 0 .631.285.631.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314" />
+      </svg>
+      Continue with Line
+    </button>
+  );
+}

--- a/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
+++ b/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
@@ -1,6 +1,8 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
 interface OAuthButtonProps {
   provider: 'google' | 'line';
-  onClick: () => void;
+  onClick: ComponentPropsWithoutRef<'button'>['onClick'];
 }
 
 export function OAuthButton({ provider, onClick }: OAuthButtonProps) {

--- a/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
+++ b/src/adapters/inbound/web/client/src/components/ui/OAuthButton.tsx
@@ -1,18 +1,17 @@
 interface OAuthButtonProps {
   provider: 'google' | 'line';
-  /** For 'google': full href for anchor redirect. For 'line': onClick handler. */
-  href?: string;
-  onClick?: () => void;
+  onClick: () => void;
 }
 
-export function OAuthButton({ provider, href, onClick }: OAuthButtonProps) {
+export function OAuthButton({ provider, onClick }: OAuthButtonProps) {
   const sharedClass =
     'flex w-full items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 cursor-pointer';
 
   if (provider === 'google') {
     return (
-      <a
-        href={href}
+      <button
+        type="button"
+        onClick={onClick}
         className={`${sharedClass} border border-gray-200 bg-white text-gray-900 hover:bg-gray-100`}
       >
         <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
@@ -22,7 +21,7 @@ export function OAuthButton({ provider, href, onClick }: OAuthButtonProps) {
           <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
         </svg>
         Continue with Google
-      </a>
+      </button>
     );
   }
 

--- a/src/adapters/inbound/web/client/src/components/ui/index.ts
+++ b/src/adapters/inbound/web/client/src/components/ui/index.ts
@@ -1,2 +1,1 @@
-// Shared UI primitives — reserved for future use
-export {};
+export { OAuthButton } from './OAuthButton';

--- a/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
+++ b/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
@@ -7,8 +7,9 @@ const ERROR_MESSAGES: Record<string, string> = {
 };
 
 async function signInWith(provider: 'google' | 'line') {
+  const apiBase = import.meta.env.VITE_API_URL ?? '';
   const endpoint =
-    provider === 'google' ? '/api/auth/sign-in/social' : '/api/auth/sign-in/oauth2';
+    provider === 'google' ? `${apiBase}/api/auth/sign-in/social` : `${apiBase}/api/auth/sign-in/oauth2`;
   const callbackURL = window.location.origin + '/';
   const body =
     provider === 'google'

--- a/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
+++ b/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
@@ -1,0 +1,50 @@
+import { useSearchParams } from 'react-router-dom';
+import { OAuthButton } from '@/components/ui/OAuthButton';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  not_invited: "This account isn't invited. Contact the owner to request access.",
+  default: 'Sign-in failed. Please try again.',
+};
+
+async function signInWithLine() {
+  const res = await fetch('/api/auth/sign-in/oauth2', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ providerId: 'line', callbackURL: '/' }),
+  });
+  const data = (await res.json()) as { url?: string };
+  if (data.url) {
+    window.location.href = data.url;
+  }
+}
+
+export function LoginPage() {
+  const [searchParams] = useSearchParams();
+  const errorKey = searchParams.get('error');
+  const errorMessage = errorKey ? (ERROR_MESSAGES[errorKey] ?? ERROR_MESSAGES.default) : null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-950 px-4">
+      <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-gray-900 p-8 shadow-xl">
+        <h1 className="mb-6 text-center text-3xl font-semibold text-white">Pax</h1>
+        <div className="mb-6 border-t border-white/10" />
+        {errorMessage && (
+          <div
+            role="alert"
+            className="mb-4 rounded-lg border border-red-800 bg-red-950 px-4 py-3 text-sm text-red-300"
+          >
+            {errorMessage}
+          </div>
+        )}
+        <div className="flex flex-col gap-3">
+          <OAuthButton
+            provider="google"
+            href="/api/auth/sign-in/social?provider=google&callbackURL=/"
+          />
+          <OAuthButton provider="line" onClick={signInWithLine} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
+++ b/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
@@ -6,12 +6,20 @@ const ERROR_MESSAGES: Record<string, string> = {
   default: 'Sign-in failed. Please try again.',
 };
 
-async function signInWithLine() {
-  const res = await fetch('/api/auth/sign-in/oauth2', {
+async function signInWith(provider: 'google' | 'line') {
+  const endpoint =
+    provider === 'google' ? '/api/auth/sign-in/social' : '/api/auth/sign-in/oauth2';
+  const callbackURL = window.location.origin + '/';
+  const body =
+    provider === 'google'
+      ? { provider: 'google', callbackURL }
+      : { providerId: 'line', callbackURL };
+
+  const res = await fetch(endpoint, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ providerId: 'line', callbackURL: '/' }),
+    body: JSON.stringify(body),
   });
   const data = (await res.json()) as { url?: string };
   if (data.url) {
@@ -38,11 +46,8 @@ export function LoginPage() {
           </div>
         )}
         <div className="flex flex-col gap-3">
-          <OAuthButton
-            provider="google"
-            href="/api/auth/sign-in/social?provider=google&callbackURL=/"
-          />
-          <OAuthButton provider="line" onClick={signInWithLine} />
+          <OAuthButton provider="google" onClick={() => signInWith('google')} />
+          <OAuthButton provider="line" onClick={() => signInWith('line')} />
         </div>
       </div>
     </div>

--- a/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
+++ b/src/adapters/inbound/web/client/src/features/auth/LoginPage.tsx
@@ -21,9 +21,15 @@ async function signInWith(provider: 'google' | 'line') {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });
+  if (!res.ok) {
+    console.error(`[auth] ${provider} sign-in request failed: ${res.status}`);
+    return;
+  }
   const data = (await res.json()) as { url?: string };
   if (data.url) {
     window.location.href = data.url;
+  } else {
+    console.error('[auth] Sign-in response missing redirect URL');
   }
 }
 

--- a/src/adapters/inbound/web/client/src/features/auth/useSession.ts
+++ b/src/adapters/inbound/web/client/src/features/auth/useSession.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+import { apiClient } from '@/lib/api-client';
+import type { SessionUser } from '@/lib/api-client';
+
+export interface UseSessionResult {
+  loading: boolean;
+  user: SessionUser | null;
+}
+
+export function useSession(): UseSessionResult {
+  const [loading, setLoading] = useState(true);
+  const [user, setUser] = useState<SessionUser | null>(null);
+
+  useEffect(() => {
+    apiClient
+      .getSession()
+      .then((data) => setUser(data?.user ?? null))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { loading, user };
+}

--- a/src/adapters/inbound/web/client/src/features/auth/useSession.ts
+++ b/src/adapters/inbound/web/client/src/features/auth/useSession.ts
@@ -15,7 +15,10 @@ export function useSession(): UseSessionResult {
     apiClient
       .getSession()
       .then((data) => setUser(data?.user ?? null))
-      .catch(() => setUser(null))
+      .catch((err: unknown) => {
+        console.error('[auth] Session fetch failed:', err);
+        setUser(null);
+      })
       .finally(() => setLoading(false));
   }, []);
 

--- a/src/adapters/inbound/web/client/src/lib/api-client.ts
+++ b/src/adapters/inbound/web/client/src/lib/api-client.ts
@@ -47,6 +47,13 @@ export interface SessionResponse {
   session: { id: string; expiresAt: string };
 }
 
+class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
 class ApiClient {
   private readonly base: string;
 
@@ -54,7 +61,7 @@ class ApiClient {
     this.base = import.meta.env.VITE_API_URL ?? '';
   }
 
-  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+  private async request<Value>(path: string, init?: RequestInit): Promise<Value> {
     const res = await fetch(`${this.base}${path}`, {
       ...init,
       credentials: 'include',
@@ -62,13 +69,16 @@ class ApiClient {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
-      throw new Error(`API ${init?.method ?? 'GET'} ${path} → ${res.status}: ${text}`);
+      throw new ApiError(`API ${init?.method ?? 'GET'} ${path} → ${res.status}: ${text}`, res.status);
     }
-    return res.json() as Promise<T>;
+    return res.json() as Promise<Value>;
   }
 
   getSession(): Promise<SessionResponse | null> {
-    return this.request<SessionResponse | null>('/api/auth/get-session').catch(() => null);
+    return this.request<SessionResponse | null>('/api/auth/get-session').catch((err: unknown) => {
+      if (err instanceof ApiError && (err.status === 401 || err.status === 403)) return null;
+      throw err;
+    });
   }
 
   getToday(): Promise<TodayResponse> {

--- a/src/adapters/inbound/web/client/src/lib/api-client.ts
+++ b/src/adapters/inbound/web/client/src/lib/api-client.ts
@@ -35,36 +35,40 @@ export interface UpdateTodoInput {
   priority?: TodoPriority;
 }
 
+export interface SessionUser {
+  id: string;
+  name: string;
+  email: string;
+  image?: string | null;
+}
+
+export interface SessionResponse {
+  user: SessionUser;
+  session: { id: string; expiresAt: string };
+}
+
 class ApiClient {
   private readonly base: string;
-  private readonly token: string;
 
   constructor() {
     this.base = import.meta.env.VITE_API_URL ?? '';
-    // TODO(#21): VITE_API_TOKEN is a temporary dev-only scaffold — a bearer token
-    // baked into the client bundle is not suitable for production. Once Better Auth
-    // is implemented (#21), auth will use httpOnly session cookies issued by the
-    // server and this env var (and the Authorization header below) can be removed.
-    this.token = import.meta.env.VITE_API_TOKEN ?? '';
-  }
-
-  private headers(): HeadersInit {
-    return {
-      'Content-Type': 'application/json',
-      ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
-    };
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(`${this.base}${path}`, {
       ...init,
-      headers: { ...this.headers(), ...(init?.headers ?? {}) },
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
     });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new Error(`API ${init?.method ?? 'GET'} ${path} → ${res.status}: ${text}`);
     }
     return res.json() as Promise<T>;
+  }
+
+  getSession(): Promise<SessionResponse | null> {
+    return this.request<SessionResponse | null>('/api/auth/get-session').catch(() => null);
   }
 
   getToday(): Promise<TodayResponse> {

--- a/src/adapters/inbound/web/client/src/lib/api-client.ts
+++ b/src/adapters/inbound/web/client/src/lib/api-client.ts
@@ -61,12 +61,12 @@ class ApiClient {
     this.base = import.meta.env.VITE_API_URL ?? '';
   }
 
-  private async request<Value>(path: string, init?: RequestInit): Promise<Value> {
-    const res = await fetch(`${this.base}${path}`, {
-      ...init,
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
-    });
+  private async request<Value>(path: string, init: RequestInit = {}): Promise<Value> {
+    const headers = new Headers(init.headers);
+    if (init.body != null && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+    const res = await fetch(`${this.base}${path}`, { ...init, credentials: 'include', headers });
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       throw new ApiError(`API ${init?.method ?? 'GET'} ${path} → ${res.status}: ${text}`, res.status);

--- a/src/adapters/inbound/web/client/vite.config.ts
+++ b/src/adapters/inbound/web/client/vite.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
+      workbox: {
+        navigateFallbackDenylist: [/^\/api\//],
+      },
       manifest: {
         name: 'Pax',
         short_name: 'Pax',

--- a/src/adapters/inbound/web/server/auth.ts
+++ b/src/adapters/inbound/web/server/auth.ts
@@ -1,0 +1,65 @@
+import { betterAuth } from 'better-auth';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { genericOAuth, line } from 'better-auth/plugins/generic-oauth';
+import { eq, isNull } from 'drizzle-orm';
+import type { TursoDb } from '../../../../adapters/outbound/turso/client';
+import { events, snapshotTodos, snapshotLogs, entityIdMap, invites } from '../../../../adapters/outbound/turso/schema';
+
+export function createAuth(db: TursoDb) {
+  const ownerEmail = process.env.OWNER_EMAIL ?? '';
+  const secret = process.env.BETTER_AUTH_SECRET ?? '';
+  if (!secret) throw new Error('BETTER_AUTH_SECRET is required');
+
+  return betterAuth({
+    secret,
+    database: drizzleAdapter(db, { provider: 'sqlite' }),
+    socialProviders: {
+      google: {
+        clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+        clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+      },
+    },
+    plugins: [
+      genericOAuth({
+        config: [
+          line({
+            clientId: process.env.LINE_CLIENT_ID ?? '',
+            clientSecret: process.env.LINE_CLIENT_SECRET ?? '',
+          }),
+        ],
+      }),
+    ],
+    databaseHooks: {
+      user: {
+        create: {
+          before: async (user) => {
+            // Allow owner unconditionally; everyone else must be in the invites table
+            if (user.email !== ownerEmail) {
+              const [invite] = await db
+                .select()
+                .from(invites)
+                .where(eq(invites.email, user.email))
+                .limit(1);
+              if (!invite) {
+                throw new Error('not_invited');
+              }
+            }
+            return { data: user };
+          },
+          after: async (user) => {
+            // Owner first login: backfill all legacy rows that have no user_id
+            if (user.email === ownerEmail) {
+              await db.update(events).set({ userId: user.id }).where(isNull(events.userId));
+              await db.update(snapshotTodos).set({ userId: user.id }).where(isNull(snapshotTodos.userId));
+              await db.update(snapshotLogs).set({ userId: user.id }).where(isNull(snapshotLogs.userId));
+              await db.update(entityIdMap).set({ userId: user.id }).where(isNull(entityIdMap.userId));
+            }
+          },
+        },
+      },
+    },
+    trustedOrigins: [process.env.BETTER_AUTH_TRUSTED_ORIGIN ?? 'http://localhost:5173'],
+  });
+}
+
+export type Auth = ReturnType<typeof createAuth>;

--- a/src/adapters/inbound/web/server/auth.ts
+++ b/src/adapters/inbound/web/server/auth.ts
@@ -9,6 +9,7 @@ export function createAuth(db: TursoDb) {
   const ownerEmail = process.env.OWNER_EMAIL ?? '';
   const secret = process.env.BETTER_AUTH_SECRET ?? '';
   if (!secret) throw new Error('BETTER_AUTH_SECRET is required');
+  if (!ownerEmail) throw new Error('OWNER_EMAIL is required');
 
   return betterAuth({
     secret,
@@ -49,10 +50,17 @@ export function createAuth(db: TursoDb) {
           after: async (user) => {
             // Owner first login: backfill all legacy rows that have no user_id
             if (user.email === ownerEmail) {
-              await db.update(events).set({ userId: user.id }).where(isNull(events.userId));
-              await db.update(snapshotTodos).set({ userId: user.id }).where(isNull(snapshotTodos.userId));
-              await db.update(snapshotLogs).set({ userId: user.id }).where(isNull(snapshotLogs.userId));
-              await db.update(entityIdMap).set({ userId: user.id }).where(isNull(entityIdMap.userId));
+              try {
+                await db.update(events).set({ userId: user.id }).where(isNull(events.userId));
+                await db.update(snapshotTodos).set({ userId: user.id }).where(isNull(snapshotTodos.userId));
+                await db.update(snapshotLogs).set({ userId: user.id }).where(isNull(snapshotLogs.userId));
+                await db.update(entityIdMap).set({ userId: user.id }).where(isNull(entityIdMap.userId));
+              } catch (err) {
+                console.error(
+                  '[auth] CRITICAL: Owner data backfill failed —',
+                  err instanceof Error ? err.message : String(err)
+                );
+              }
             }
           },
         },

--- a/src/adapters/inbound/web/server/auth.ts
+++ b/src/adapters/inbound/web/server/auth.ts
@@ -1,9 +1,9 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
-import { genericOAuth, line } from 'better-auth/plugins/generic-oauth';
-import { eq, isNull } from 'drizzle-orm';
+import { genericOAuth, line } from 'better-auth/plugins';
+import { eq } from 'drizzle-orm';
 import type { TursoDb } from '../../../../adapters/outbound/turso/client';
-import { events, snapshotTodos, snapshotLogs, entityIdMap, invites, users, sessions, accounts, verifications } from '../../../../adapters/outbound/turso/schema';
+import { invites, users, sessions, accounts, verifications } from '../../../../adapters/outbound/turso/schema';
 
 export function createAuth(db: TursoDb) {
   const ownerEmail = process.env.OWNER_EMAIL ?? '';
@@ -58,24 +58,6 @@ export function createAuth(db: TursoDb) {
               }
             }
             return { data: user };
-          },
-          after: async (user) => {
-            // Owner first login: backfill all legacy rows that have no user_id.
-            // snapshot tables had NULL rows converted to '__unscoped__' by migration 0003;
-            // events table still uses NULL (no NOT NULL constraint added there).
-            if (user.email.toLowerCase() === ownerEmailNormalized) {
-              try {
-                await db.update(events).set({ userId: user.id }).where(isNull(events.userId));
-                await db.update(snapshotTodos).set({ userId: user.id }).where(eq(snapshotTodos.userId, '__unscoped__'));
-                await db.update(snapshotLogs).set({ userId: user.id }).where(eq(snapshotLogs.userId, '__unscoped__'));
-                await db.update(entityIdMap).set({ userId: user.id }).where(eq(entityIdMap.userId, '__unscoped__'));
-              } catch (err) {
-                console.error(
-                  '[auth] CRITICAL: Owner data backfill failed —',
-                  err instanceof Error ? err.message : String(err)
-                );
-              }
-            }
           },
         },
       },

--- a/src/adapters/inbound/web/server/auth.ts
+++ b/src/adapters/inbound/web/server/auth.ts
@@ -3,7 +3,7 @@ import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { genericOAuth, line } from 'better-auth/plugins/generic-oauth';
 import { eq, isNull } from 'drizzle-orm';
 import type { TursoDb } from '../../../../adapters/outbound/turso/client';
-import { events, snapshotTodos, snapshotLogs, entityIdMap, invites } from '../../../../adapters/outbound/turso/schema';
+import { events, snapshotTodos, snapshotLogs, entityIdMap, invites, users, sessions, accounts, verifications } from '../../../../adapters/outbound/turso/schema';
 
 export function createAuth(db: TursoDb) {
   const ownerEmail = process.env.OWNER_EMAIL ?? '';
@@ -13,7 +13,10 @@ export function createAuth(db: TursoDb) {
 
   return betterAuth({
     secret,
-    database: drizzleAdapter(db, { provider: 'sqlite' }),
+    database: drizzleAdapter(db, {
+      provider: 'sqlite',
+      schema: { user: users, session: sessions, account: accounts, verification: verifications },
+    }),
     socialProviders: {
       google: {
         clientId: process.env.GOOGLE_CLIENT_ID ?? '',

--- a/src/adapters/inbound/web/server/auth.ts
+++ b/src/adapters/inbound/web/server/auth.ts
@@ -11,6 +11,15 @@ export function createAuth(db: TursoDb) {
   if (!secret) throw new Error('BETTER_AUTH_SECRET is required');
   if (!ownerEmail) throw new Error('OWNER_EMAIL is required');
 
+  const ownerEmailNormalized = ownerEmail.toLowerCase();
+
+  if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
+    console.warn('[auth] Google OAuth credentials not configured');
+  }
+  if (!process.env.LINE_CLIENT_ID || !process.env.LINE_CLIENT_SECRET) {
+    console.warn('[auth] LINE OAuth credentials not configured');
+  }
+
   return betterAuth({
     secret,
     database: drizzleAdapter(db, {
@@ -38,11 +47,11 @@ export function createAuth(db: TursoDb) {
         create: {
           before: async (user) => {
             // Allow owner unconditionally; everyone else must be in the invites table
-            if (user.email !== ownerEmail) {
+            if (user.email.toLowerCase() !== ownerEmailNormalized) {
               const [invite] = await db
                 .select()
                 .from(invites)
-                .where(eq(invites.email, user.email))
+                .where(eq(invites.email, user.email.toLowerCase()))
                 .limit(1);
               if (!invite) {
                 throw new Error('not_invited');
@@ -51,13 +60,15 @@ export function createAuth(db: TursoDb) {
             return { data: user };
           },
           after: async (user) => {
-            // Owner first login: backfill all legacy rows that have no user_id
-            if (user.email === ownerEmail) {
+            // Owner first login: backfill all legacy rows that have no user_id.
+            // snapshot tables had NULL rows converted to '__unscoped__' by migration 0003;
+            // events table still uses NULL (no NOT NULL constraint added there).
+            if (user.email.toLowerCase() === ownerEmailNormalized) {
               try {
                 await db.update(events).set({ userId: user.id }).where(isNull(events.userId));
-                await db.update(snapshotTodos).set({ userId: user.id }).where(isNull(snapshotTodos.userId));
-                await db.update(snapshotLogs).set({ userId: user.id }).where(isNull(snapshotLogs.userId));
-                await db.update(entityIdMap).set({ userId: user.id }).where(isNull(entityIdMap.userId));
+                await db.update(snapshotTodos).set({ userId: user.id }).where(eq(snapshotTodos.userId, '__unscoped__'));
+                await db.update(snapshotLogs).set({ userId: user.id }).where(eq(snapshotLogs.userId, '__unscoped__'));
+                await db.update(entityIdMap).set({ userId: user.id }).where(eq(entityIdMap.userId, '__unscoped__'));
               } catch (err) {
                 console.error(
                   '[auth] CRITICAL: Owner data backfill failed —',

--- a/src/adapters/inbound/web/server/index.ts
+++ b/src/adapters/inbound/web/server/index.ts
@@ -2,7 +2,7 @@ import type { TodoAddInputDto } from '@app/todo/todo-dto';
 import type { TodoUpdatePatch } from '@app/todo/todo-update-patch';
 import { join, resolve, relative } from 'path';
 import { migrate } from 'drizzle-orm/libsql/migrator';
-import { Elysia } from 'elysia';
+import { Elysia, t } from 'elysia';
 import { createTursoDb } from '../../../../adapters/outbound/turso/client';
 import { getResolvedConfig } from '../../../../config/resolved';
 import { getConfigDir } from '../../../../config/config-dir';
@@ -76,17 +76,43 @@ new Elysia()
             todos: await c.todosUseCase.listOpen(),
           }))
           .get('/todos', ({ c }) => c.todosUseCase.listOpen())
-          .post('/todos', async ({ c, body }) => {
-            const todo = await c.todosUseCase.add(body as TodoAddInputDto);
-            return new Response(JSON.stringify(todo), {
-              status: 201,
-              headers: { 'Content-Type': 'application/json' },
-            });
-          })
-          .patch('/todos/:id', async ({ c, params, body }) => {
-            await c.todosUseCase.updateByIdOrIndex(params.id, body as TodoUpdatePatch);
-            return { ok: true };
-          })
+          .post(
+            '/todos',
+            async ({ c, body }) => {
+              const todo = await c.todosUseCase.add(body as TodoAddInputDto);
+              return new Response(JSON.stringify(todo), {
+                status: 201,
+                headers: { 'Content-Type': 'application/json' },
+              });
+            },
+            {
+              body: t.Object({
+                title: t.String(),
+                dueDate: t.Optional(t.Nullable(t.String())),
+                category: t.Optional(t.String()),
+                notes: t.Optional(t.String()),
+                priority: t.Optional(t.String()),
+                status: t.Optional(t.String()),
+              }),
+            }
+          )
+          .patch(
+            '/todos/:id',
+            async ({ c, params, body }) => {
+              await c.todosUseCase.updateByIdOrIndex(params.id, body as TodoUpdatePatch);
+              return { ok: true };
+            },
+            {
+              body: t.Object({
+                title: t.Optional(t.String()),
+                dueDate: t.Optional(t.Nullable(t.String())),
+                status: t.Optional(t.String()),
+                category: t.Optional(t.String()),
+                notes: t.Optional(t.String()),
+                priority: t.Optional(t.String()),
+              }),
+            }
+          )
           .post('/todos/:id/complete', async ({ c, params }) => {
             await c.todosUseCase.completeByIdOrIndex(params.id);
             return { ok: true };
@@ -95,6 +121,15 @@ new Elysia()
   )
 
   // SPA fallback — static files and index.html
-  .all('/*', ({ request }) => serveStatic(new URL(request.url).pathname))
+  .all('/*', ({ request }) => {
+    const pathname = new URL(request.url).pathname;
+    if (pathname === '/api' || pathname.startsWith('/api/')) {
+      return new Response(JSON.stringify({ error: 'Not Found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return serveStatic(pathname);
+  })
 
   .listen(PORT, () => console.log(`Pax web server: http://localhost:${PORT}`));

--- a/src/adapters/inbound/web/server/index.ts
+++ b/src/adapters/inbound/web/server/index.ts
@@ -11,7 +11,7 @@ import { getCompositionForUser } from './user-composition';
 
 const PORT = Number(process.env.PORT ?? 3001);
 const PUBLIC_DIR = join(import.meta.dir, 'public');
-const OWNER_EMAIL = process.env.OWNER_EMAIL ?? '';
+const OWNER_EMAIL = (process.env.OWNER_EMAIL ?? '').trim().toLowerCase();
 
 const { settings } = getResolvedConfig();
 const configDir = getConfigDir();
@@ -67,7 +67,7 @@ new Elysia()
           .resolve(async ({ request }) => {
             const session = (await auth.api.getSession({ headers: request.headers }))!;
             const { id: userId, email } = session.user;
-            const isOwner = email === OWNER_EMAIL;
+            const isOwner = email.toLowerCase() === OWNER_EMAIL;
             const c = await getCompositionForUser(db, userId, isOwner);
             return { c };
           })

--- a/src/adapters/inbound/web/server/index.ts
+++ b/src/adapters/inbound/web/server/index.ts
@@ -1,18 +1,33 @@
-import { compose } from '../../../../composition';
-import type { Composition } from '../../../../composition';
 import type { TodoAddInputDto } from '@app/todo/todo-dto';
 import type { TodoUpdatePatch } from '@app/todo/todo-update-patch';
 import { join, resolve, relative } from 'path';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { createTursoDb } from '../../../../adapters/outbound/turso/client';
+import { getResolvedConfig } from '../../../../config/resolved';
+import { getConfigDir } from '../../../../config/config-dir';
+import { createAuth } from './auth';
+import { getCompositionForUser } from './user-composition';
 
 const PORT = Number(process.env.PORT ?? 3001);
-const AUTH_TOKEN = process.env.WEB_AUTH_TOKEN ?? '';
 const PUBLIC_DIR = join(import.meta.dir, 'public');
+const OWNER_EMAIL = process.env.OWNER_EMAIL ?? '';
 
-let compositionPromise: Promise<Composition> | null = null;
-function getComposition(): Promise<Composition> {
-  compositionPromise = compositionPromise ?? compose();
-  return compositionPromise;
-}
+const { settings } = getResolvedConfig();
+const configDir = getConfigDir();
+const dbPath = join(configDir, 'turso.db');
+const db = createTursoDb({
+  tursoUrl: settings.TURSO_URL ?? '',
+  tursoToken: settings.TURSO_TOKEN ?? '',
+  mode: 'embedded',
+  localDbPath: dbPath,
+});
+
+// Run migrations once at startup before serving any request
+await migrate(db, {
+  migrationsFolder: join(import.meta.dir, '../../../../adapters/outbound/turso/migrations'),
+});
+
+const auth = createAuth(db);
 
 function unauthorized(): Response {
   return new Response(JSON.stringify({ error: 'Unauthorized' }), {
@@ -33,12 +48,6 @@ function notFound(): Response {
     status: 404,
     headers: { 'Content-Type': 'application/json' },
   });
-}
-
-function checkAuth(req: Request): boolean {
-  if (!AUTH_TOKEN) return true;
-  const header = req.headers.get('Authorization') ?? '';
-  return header === `Bearer ${AUTH_TOKEN}`;
 }
 
 async function serveStatic(pathname: string): Promise<Response> {
@@ -62,10 +71,18 @@ Bun.serve({
     const { pathname } = url;
     const method = req.method.toUpperCase();
 
-    if (pathname.startsWith('/api/')) {
-      if (!checkAuth(req)) return unauthorized();
+    // Better Auth owns all /api/auth/* routes
+    if (pathname.startsWith('/api/auth/')) {
+      return auth.handler(req);
+    }
 
-      const c = await getComposition();
+    if (pathname.startsWith('/api/')) {
+      const session = await auth.api.getSession({ headers: req.headers });
+      if (!session) return unauthorized();
+
+      const userId = session.user.id;
+      const isOwner = session.user.email === OWNER_EMAIL;
+      const c = await getCompositionForUser(db, userId, isOwner);
 
       if (method === 'GET' && pathname === '/api/today') {
         const todos = await c.todosUseCase.listOpen();

--- a/src/adapters/inbound/web/server/index.ts
+++ b/src/adapters/inbound/web/server/index.ts
@@ -1,5 +1,6 @@
 import type { TodoAddInputDto } from '@app/todo/todo-dto';
 import type { TodoUpdatePatch } from '@app/todo/todo-update-patch';
+import { TODO_PRIORITIES } from '@domain/todo/todo';
 import { join, resolve, relative } from 'path';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import { Elysia, t } from 'elysia';
@@ -8,6 +9,8 @@ import { getResolvedConfig } from '../../../../config/resolved';
 import { getConfigDir } from '../../../../config/config-dir';
 import { createAuth } from './auth';
 import { getCompositionForUser } from './user-composition';
+
+const TODO_STATUS_VALUES = ['Todo', 'In Progress', 'Done'];
 
 const PORT = Number(process.env.PORT ?? 3001);
 const PUBLIC_DIR = join(import.meta.dir, 'public');
@@ -52,20 +55,23 @@ new Elysia()
   .group('/api', (api) =>
     api.guard(
       {
-        beforeHandle: async ({ request }) => {
+        beforeHandle: async ({ request, store }) => {
           const session = await auth.api.getSession({ headers: request.headers });
           if (!session)
             return new Response(JSON.stringify({ error: 'Unauthorized' }), {
               status: 401,
               headers: { 'Content-Type': 'application/json' },
             });
+          // Store session in request context to avoid re-fetching in resolve
+          (store as { session?: typeof session }).session = session;
         },
       },
       (guarded) =>
         guarded
-          // resolve runs after beforeHandle — session is guaranteed valid here
-          .resolve(async ({ request }) => {
-            const session = (await auth.api.getSession({ headers: request.headers }))!;
+          // resolve runs after beforeHandle — session is guaranteed valid and stored in context
+          .resolve(async ({ store }) => {
+            const stored = store as { session?: { user: { id: string; email: string } } };
+            const session = stored.session!;
             const { id: userId, email } = session.user;
             const isOwner = email.toLowerCase() === OWNER_EMAIL;
             const c = await getCompositionForUser(db, userId, isOwner);
@@ -91,8 +97,8 @@ new Elysia()
                 dueDate: t.Optional(t.Nullable(t.String())),
                 category: t.Optional(t.String()),
                 notes: t.Optional(t.String()),
-                priority: t.Optional(t.String()),
-                status: t.Optional(t.String()),
+                priority: t.Optional(t.Union(TODO_PRIORITIES.map((p) => t.Literal(p)))),
+                status: t.Optional(t.Union(TODO_STATUS_VALUES.map((s) => t.Literal(s)))),
               }),
             }
           )
@@ -106,10 +112,10 @@ new Elysia()
               body: t.Object({
                 title: t.Optional(t.String()),
                 dueDate: t.Optional(t.Nullable(t.String())),
-                status: t.Optional(t.String()),
+                status: t.Optional(t.Union(TODO_STATUS_VALUES.map((s) => t.Literal(s)))),
                 category: t.Optional(t.String()),
                 notes: t.Optional(t.String()),
-                priority: t.Optional(t.String()),
+                priority: t.Optional(t.Union(TODO_PRIORITIES.map((p) => t.Literal(p)))),
               }),
             }
           )

--- a/src/adapters/inbound/web/server/index.ts
+++ b/src/adapters/inbound/web/server/index.ts
@@ -2,6 +2,7 @@ import type { TodoAddInputDto } from '@app/todo/todo-dto';
 import type { TodoUpdatePatch } from '@app/todo/todo-update-patch';
 import { join, resolve, relative } from 'path';
 import { migrate } from 'drizzle-orm/libsql/migrator';
+import { Elysia } from 'elysia';
 import { createTursoDb } from '../../../../adapters/outbound/turso/client';
 import { getResolvedConfig } from '../../../../config/resolved';
 import { getConfigDir } from '../../../../config/config-dir';
@@ -29,27 +30,6 @@ await migrate(db, {
 
 const auth = createAuth(db);
 
-function unauthorized(): Response {
-  return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-    status: 401,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
-
-function json<T>(data: T, status = 200): Response {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
-
-function notFound(): Response {
-  return new Response(JSON.stringify({ error: 'Not found' }), {
-    status: 404,
-    headers: { 'Content-Type': 'application/json' },
-  });
-}
-
 async function serveStatic(pathname: string): Promise<Response> {
   const decoded = decodeURIComponent(pathname.split('?')[0]).replace(/\0/g, '');
   const resolved = resolve(join(PUBLIC_DIR, decoded));
@@ -64,75 +44,57 @@ async function serveStatic(pathname: string): Promise<Response> {
   return new Response(Bun.file(join(PUBLIC_DIR, 'index.html')));
 }
 
-Bun.serve({
-  port: PORT,
-  async fetch(req: Request): Promise<Response> {
-    const url = new URL(req.url);
-    const { pathname } = url;
-    const method = req.method.toUpperCase();
+new Elysia()
+  // Better Auth owns all /api/auth/* routes
+  .all('/api/auth/*', ({ request }) => auth.handler(request))
 
-    // Better Auth owns all /api/auth/* routes
-    if (pathname.startsWith('/api/auth/')) {
-      return auth.handler(req);
-    }
+  // Protected API routes — session guard + composition derive
+  .group('/api', (api) =>
+    api.guard(
+      {
+        beforeHandle: async ({ request }) => {
+          const session = await auth.api.getSession({ headers: request.headers });
+          if (!session)
+            return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+        },
+      },
+      (guarded) =>
+        guarded
+          // resolve runs after beforeHandle — session is guaranteed valid here
+          .resolve(async ({ request }) => {
+            const session = (await auth.api.getSession({ headers: request.headers }))!;
+            const { id: userId, email } = session.user;
+            const isOwner = email === OWNER_EMAIL;
+            const c = await getCompositionForUser(db, userId, isOwner);
+            return { c };
+          })
+          .get('/today', async ({ c }) => ({
+            date: new Date().toISOString().slice(0, 10),
+            todos: await c.todosUseCase.listOpen(),
+          }))
+          .get('/todos', ({ c }) => c.todosUseCase.listOpen())
+          .post('/todos', async ({ c, body }) => {
+            const todo = await c.todosUseCase.add(body as TodoAddInputDto);
+            return new Response(JSON.stringify(todo), {
+              status: 201,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          })
+          .patch('/todos/:id', async ({ c, params, body }) => {
+            await c.todosUseCase.updateByIdOrIndex(params.id, body as TodoUpdatePatch);
+            return { ok: true };
+          })
+          .post('/todos/:id/complete', async ({ c, params }) => {
+            await c.todosUseCase.completeByIdOrIndex(params.id);
+            return { ok: true };
+          })
+    )
+  )
 
-    if (pathname.startsWith('/api/')) {
-      const session = await auth.api.getSession({ headers: req.headers });
-      if (!session) return unauthorized();
+  // SPA fallback — static files and index.html
+  .all('/*', ({ request }) => serveStatic(new URL(request.url).pathname))
 
-      const userId = session.user.id;
-      const isOwner = session.user.email === OWNER_EMAIL;
-      const c = await getCompositionForUser(db, userId, isOwner);
-
-      if (method === 'GET' && pathname === '/api/today') {
-        const todos = await c.todosUseCase.listOpen();
-        return json({
-          date: new Date().toISOString().slice(0, 10),
-          todos,
-        });
-      }
-
-      if (method === 'GET' && pathname === '/api/todos') {
-        const todos = await c.todosUseCase.listOpen();
-        return json(todos);
-      }
-
-      if (method === 'POST' && pathname === '/api/todos') {
-        let body: TodoAddInputDto;
-        try {
-          body = await req.json() as TodoAddInputDto;
-        } catch {
-          return json({ error: 'Malformed JSON' }, 400);
-        }
-        const todo = await c.todosUseCase.add(body);
-        return json(todo, 201);
-      }
-
-      const patchMatch = /^\/api\/todos\/([^/]+)$/.exec(pathname);
-      if (method === 'PATCH' && patchMatch) {
-        const id = patchMatch[1]!;
-        let patch: TodoUpdatePatch;
-        try {
-          patch = await req.json() as TodoUpdatePatch;
-        } catch {
-          return json({ error: 'Malformed JSON' }, 400);
-        }
-        await c.todosUseCase.updateByIdOrIndex(id, patch);
-        return json({ ok: true });
-      }
-
-      const completeMatch = /^\/api\/todos\/([^/]+)\/complete$/.exec(pathname);
-      if (method === 'POST' && completeMatch) {
-        const id = completeMatch[1]!;
-        await c.todosUseCase.completeByIdOrIndex(id);
-        return json({ ok: true });
-      }
-
-      return notFound();
-    }
-
-    return serveStatic(pathname);
-  },
-});
-
-console.log(`Pax web server: http://localhost:${PORT}`);
+  .listen(PORT, () => console.log(`Pax web server: http://localhost:${PORT}`));

--- a/src/adapters/inbound/web/server/user-composition.ts
+++ b/src/adapters/inbound/web/server/user-composition.ts
@@ -1,0 +1,18 @@
+import type { TursoDb } from '../../../../adapters/outbound/turso/client';
+import type { Composition } from '../../../../composition';
+import { composeForUser } from '../../../../composition';
+
+const cache = new Map<string, Promise<Composition>>();
+
+export function getCompositionForUser(
+  db: TursoDb,
+  userId: string,
+  isOwner: boolean,
+): Promise<Composition> {
+  let promise = cache.get(userId);
+  if (!promise) {
+    promise = composeForUser(db, userId, isOwner);
+    cache.set(userId, promise);
+  }
+  return promise;
+}

--- a/src/adapters/inbound/web/server/user-composition.ts
+++ b/src/adapters/inbound/web/server/user-composition.ts
@@ -9,13 +9,14 @@ export function getCompositionForUser(
   userId: string,
   isOwner: boolean,
 ): Promise<Composition> {
-  let promise = cache.get(userId);
+  const cacheKey = `${userId}:${isOwner}`;
+  let promise = cache.get(cacheKey);
   if (!promise) {
     promise = composeForUser(db, userId, isOwner).catch((err: unknown) => {
-      cache.delete(userId);
+      cache.delete(cacheKey);
       throw err;
     });
-    cache.set(userId, promise);
+    cache.set(cacheKey, promise);
   }
   return promise;
 }

--- a/src/adapters/inbound/web/server/user-composition.ts
+++ b/src/adapters/inbound/web/server/user-composition.ts
@@ -11,7 +11,10 @@ export function getCompositionForUser(
 ): Promise<Composition> {
   let promise = cache.get(userId);
   if (!promise) {
-    promise = composeForUser(db, userId, isOwner);
+    promise = composeForUser(db, userId, isOwner).catch((err: unknown) => {
+      cache.delete(userId);
+      throw err;
+    });
     cache.set(userId, promise);
   }
   return promise;

--- a/src/adapters/outbound/turso/migrations/0002_cool_slyde.sql
+++ b/src/adapters/outbound/turso/migrations/0002_cool_slyde.sql
@@ -1,0 +1,60 @@
+CREATE TABLE `account` (
+	`id` text PRIMARY KEY NOT NULL,
+	`account_id` text NOT NULL,
+	`provider_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`id_token` text,
+	`access_token_expires_at` integer,
+	`refresh_token_expires_at` integer,
+	`scope` text,
+	`password` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE TABLE `invites` (
+	`email` text PRIMARY KEY NOT NULL,
+	`invited_by` text NOT NULL,
+	`invited_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `session` (
+	`id` text PRIMARY KEY NOT NULL,
+	`expires_at` integer NOT NULL,
+	`token` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`ip_address` text,
+	`user_agent` text,
+	`user_id` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
+CREATE TABLE `user` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL,
+	`email_verified` integer DEFAULT false NOT NULL,
+	`image` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
+CREATE TABLE `verification` (
+	`id` text PRIMARY KEY NOT NULL,
+	`identifier` text NOT NULL,
+	`value` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer,
+	`updated_at` integer
+);
+--> statement-breakpoint
+ALTER TABLE `entity_id_map` ADD `user_id` text;--> statement-breakpoint
+ALTER TABLE `events` ADD `user_id` text;--> statement-breakpoint
+ALTER TABLE `snapshot_logs` ADD `user_id` text;--> statement-breakpoint
+ALTER TABLE `snapshot_todos` ADD `user_id` text;

--- a/src/adapters/outbound/turso/migrations/0003_composite_user_pk.sql
+++ b/src/adapters/outbound/turso/migrations/0003_composite_user_pk.sql
@@ -1,0 +1,49 @@
+-- Assign legacy NULL user_ids to placeholder scope before making NOT NULL
+UPDATE `snapshot_todos` SET `user_id` = '__unscoped__' WHERE `user_id` IS NULL;
+--> statement-breakpoint
+UPDATE `snapshot_logs` SET `user_id` = '__unscoped__' WHERE `user_id` IS NULL;
+--> statement-breakpoint
+UPDATE `entity_id_map` SET `user_id` = '__unscoped__' WHERE `user_id` IS NULL;
+--> statement-breakpoint
+CREATE TABLE `snapshot_todos_new` (
+	`user_id` text NOT NULL,
+	`notion_id` text NOT NULL,
+	`data` text NOT NULL,
+	`fetched_at` text NOT NULL,
+	PRIMARY KEY(`user_id`, `notion_id`)
+);
+--> statement-breakpoint
+INSERT INTO `snapshot_todos_new` SELECT `user_id`, `notion_id`, `data`, `fetched_at` FROM `snapshot_todos`;
+--> statement-breakpoint
+DROP TABLE `snapshot_todos`;
+--> statement-breakpoint
+ALTER TABLE `snapshot_todos_new` RENAME TO `snapshot_todos`;
+--> statement-breakpoint
+CREATE TABLE `snapshot_logs_new` (
+	`user_id` text NOT NULL,
+	`date` text NOT NULL,
+	`data` text NOT NULL,
+	`fetched_at` text NOT NULL,
+	PRIMARY KEY(`user_id`, `date`)
+);
+--> statement-breakpoint
+INSERT INTO `snapshot_logs_new` SELECT `user_id`, `date`, `data`, `fetched_at` FROM `snapshot_logs`;
+--> statement-breakpoint
+DROP TABLE `snapshot_logs`;
+--> statement-breakpoint
+ALTER TABLE `snapshot_logs_new` RENAME TO `snapshot_logs`;
+--> statement-breakpoint
+CREATE TABLE `entity_id_map_new` (
+	`user_id` text NOT NULL,
+	`local_id` text NOT NULL,
+	`notion_id` text NOT NULL,
+	PRIMARY KEY(`user_id`, `local_id`)
+);
+--> statement-breakpoint
+INSERT INTO `entity_id_map_new` SELECT `user_id`, `local_id`, `notion_id` FROM `entity_id_map`;
+--> statement-breakpoint
+DROP TABLE `entity_id_map`;
+--> statement-breakpoint
+ALTER TABLE `entity_id_map_new` RENAME TO `entity_id_map`;
+--> statement-breakpoint
+CREATE INDEX `idx_events_user_id` ON `events` (`user_id`);

--- a/src/adapters/outbound/turso/migrations/0004_rehome_tui_scope.sql
+++ b/src/adapters/outbound/turso/migrations/0004_rehome_tui_scope.sql
@@ -1,0 +1,8 @@
+-- Re-home pre-auth TUI rows: snapshots went to __unscoped__, events stayed NULL
+UPDATE `events` SET `user_id` = '__tui__' WHERE `user_id` IS NULL;
+--> statement-breakpoint
+UPDATE `snapshot_todos` SET `user_id` = '__tui__' WHERE `user_id` = '__unscoped__';
+--> statement-breakpoint
+UPDATE `snapshot_logs` SET `user_id` = '__tui__' WHERE `user_id` = '__unscoped__';
+--> statement-breakpoint
+UPDATE `entity_id_map` SET `user_id` = '__tui__' WHERE `user_id` = '__unscoped__';

--- a/src/adapters/outbound/turso/migrations/meta/0002_snapshot.json
+++ b/src/adapters/outbound/turso/migrations/meta/0002_snapshot.json
@@ -1,0 +1,578 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "947db339-8f99-4574-9e84-93477254c9a7",
+  "prevId": "14ac36c1-c5fa-4732-acba-6c9d420906f7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "entity_id_map": {
+      "name": "entity_id_map",
+      "columns": {
+        "local_id": {
+          "name": "local_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced": {
+          "name": "synced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_unsynced": {
+          "name": "idx_events_unsynced",
+          "columns": [
+            "synced",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_events_type_timestamp": {
+          "name": "idx_events_type_timestamp",
+          "columns": [
+            "event_type",
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_events_entity_id_id": {
+          "name": "idx_events_entity_id_id",
+          "columns": [
+            "entity_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invites": {
+      "name": "invites",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "snapshot_logs": {
+      "name": "snapshot_logs",
+      "columns": {
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "snapshot_todos": {
+      "name": "snapshot_todos",
+      "columns": {
+        "notion_id": {
+          "name": "notion_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/adapters/outbound/turso/migrations/meta/_journal.json
+++ b/src/adapters/outbound/turso/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773461454383,
       "tag": "0001_same_vargas",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1773488545049,
+      "tag": "0002_cool_slyde",
+      "breakpoints": true
     }
   ]
 }

--- a/src/adapters/outbound/turso/migrations/meta/_journal.json
+++ b/src/adapters/outbound/turso/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773488545049,
       "tag": "0002_cool_slyde",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1742032800000,
+      "tag": "0003_composite_user_pk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/adapters/outbound/turso/migrations/meta/_journal.json
+++ b/src/adapters/outbound/turso/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1742032800000,
       "tag": "0003_composite_user_pk",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1742119200000,
+      "tag": "0004_rehome_tui_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/src/adapters/outbound/turso/schema.ts
+++ b/src/adapters/outbound/turso/schema.ts
@@ -1,5 +1,7 @@
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
 
+// ─── App tables ──────────────────────────────────────────────────────────────
+
 export const events = sqliteTable(
   'events',
   {
@@ -11,6 +13,7 @@ export const events = sqliteTable(
     timestamp: text('timestamp').notNull(),
     deviceId: text('device_id').notNull(),
     synced: integer('synced').notNull().default(0),
+    userId: text('user_id'),
   },
   (t) => [
     index('idx_events_unsynced').on(t.synced, t.id),
@@ -23,15 +26,76 @@ export const snapshotTodos = sqliteTable('snapshot_todos', {
   notionId: text('notion_id').primaryKey(),
   data: text('data').notNull(),
   fetchedAt: text('fetched_at').notNull(),
+  userId: text('user_id'),
 });
 
 export const snapshotLogs = sqliteTable('snapshot_logs', {
   date: text('date').primaryKey(),
   data: text('data').notNull(),
   fetchedAt: text('fetched_at').notNull(),
+  userId: text('user_id'),
 });
 
 export const entityIdMap = sqliteTable('entity_id_map', {
   localId: text('local_id').primaryKey(),
   notionId: text('notion_id').notNull(),
+  userId: text('user_id'),
+});
+
+export const invites = sqliteTable('invites', {
+  email: text('email').primaryKey(),
+  invitedBy: text('invited_by').notNull(),
+  invitedAt: text('invited_at').notNull(),
+});
+
+// ─── Better Auth tables ───────────────────────────────────────────────────────
+
+export const users = sqliteTable('user', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  email: text('email').notNull().unique(),
+  emailVerified: integer('email_verified', { mode: 'boolean' }).notNull().default(false),
+  image: text('image'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+});
+
+export const sessions = sqliteTable('session', {
+  id: text('id').primaryKey(),
+  expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+  token: text('token').notNull().unique(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+  ipAddress: text('ip_address'),
+  userAgent: text('user_agent'),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+});
+
+export const accounts = sqliteTable('account', {
+  id: text('id').primaryKey(),
+  accountId: text('account_id').notNull(),
+  providerId: text('provider_id').notNull(),
+  userId: text('user_id')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  accessToken: text('access_token'),
+  refreshToken: text('refresh_token'),
+  idToken: text('id_token'),
+  accessTokenExpiresAt: integer('access_token_expires_at', { mode: 'timestamp' }),
+  refreshTokenExpiresAt: integer('refresh_token_expires_at', { mode: 'timestamp' }),
+  scope: text('scope'),
+  password: text('password'),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
+});
+
+export const verifications = sqliteTable('verification', {
+  id: text('id').primaryKey(),
+  identifier: text('identifier').notNull(),
+  value: text('value').notNull(),
+  expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }),
 });

--- a/src/adapters/outbound/turso/schema.ts
+++ b/src/adapters/outbound/turso/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index, primaryKey } from 'drizzle-orm/sqlite-core';
 
 // ─── App tables ──────────────────────────────────────────────────────────────
 
@@ -19,28 +19,41 @@ export const events = sqliteTable(
     index('idx_events_unsynced').on(t.synced, t.id),
     index('idx_events_type_timestamp').on(t.eventType, t.timestamp),
     index('idx_events_entity_id_id').on(t.entityId, t.id),
+    index('idx_events_user_id').on(t.userId),
   ]
 );
 
-export const snapshotTodos = sqliteTable('snapshot_todos', {
-  notionId: text('notion_id').primaryKey(),
-  data: text('data').notNull(),
-  fetchedAt: text('fetched_at').notNull(),
-  userId: text('user_id'),
-});
+export const snapshotTodos = sqliteTable(
+  'snapshot_todos',
+  {
+    userId: text('user_id').notNull(),
+    notionId: text('notion_id').notNull(),
+    data: text('data').notNull(),
+    fetchedAt: text('fetched_at').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.notionId] })]
+);
 
-export const snapshotLogs = sqliteTable('snapshot_logs', {
-  date: text('date').primaryKey(),
-  data: text('data').notNull(),
-  fetchedAt: text('fetched_at').notNull(),
-  userId: text('user_id'),
-});
+export const snapshotLogs = sqliteTable(
+  'snapshot_logs',
+  {
+    userId: text('user_id').notNull(),
+    date: text('date').notNull(),
+    data: text('data').notNull(),
+    fetchedAt: text('fetched_at').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.date] })]
+);
 
-export const entityIdMap = sqliteTable('entity_id_map', {
-  localId: text('local_id').primaryKey(),
-  notionId: text('notion_id').notNull(),
-  userId: text('user_id'),
-});
+export const entityIdMap = sqliteTable(
+  'entity_id_map',
+  {
+    userId: text('user_id').notNull(),
+    localId: text('local_id').notNull(),
+    notionId: text('notion_id').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.userId, t.localId] })]
+);
 
 export const invites = sqliteTable('invites', {
   email: text('email').primaryKey(),

--- a/src/adapters/outbound/turso/turso-event-queue.ts
+++ b/src/adapters/outbound/turso/turso-event-queue.ts
@@ -80,7 +80,7 @@ export class TursoEventQueue implements IEventQueue {
           .insert(snapshotTodos)
           .values(todoRows)
           .onConflictDoUpdate({
-            target: snapshotTodos.notionId,
+            target: [snapshotTodos.userId, snapshotTodos.notionId],
             set: { data: sql`excluded.data`, fetchedAt: sql`excluded.fetched_at` },
           });
       }
@@ -96,7 +96,7 @@ export class TursoEventQueue implements IEventQueue {
           .insert(snapshotLogs)
           .values(logRows)
           .onConflictDoUpdate({
-            target: snapshotLogs.date,
+            target: [snapshotLogs.userId, snapshotLogs.date],
             set: { data: sql`excluded.data`, fetchedAt: sql`excluded.fetched_at` },
           });
       }
@@ -128,7 +128,7 @@ export class TursoEventQueue implements IEventQueue {
       .insert(snapshotLogs)
       .values({ date: log.date, data: JSON.stringify(log), fetchedAt: now, userId: this.userId })
       .onConflictDoUpdate({
-        target: snapshotLogs.date,
+        target: [snapshotLogs.userId, snapshotLogs.date],
         set: { data: JSON.stringify(log), fetchedAt: now },
       });
   }
@@ -150,7 +150,7 @@ export class TursoEventQueue implements IEventQueue {
       .insert(entityIdMap)
       .values({ localId, notionId, userId: this.userId })
       .onConflictDoUpdate({
-        target: entityIdMap.localId,
+        target: [entityIdMap.userId, entityIdMap.localId],
         set: { notionId },
       });
   }

--- a/src/adapters/outbound/turso/turso-event-queue.ts
+++ b/src/adapters/outbound/turso/turso-event-queue.ts
@@ -10,7 +10,10 @@ import type { TursoDb } from './client';
 import { events, snapshotTodos, snapshotLogs, entityIdMap } from './schema';
 
 export class TursoEventQueue implements IEventQueue {
-  constructor(private readonly db: TursoDb) {}
+  constructor(
+    private readonly db: TursoDb,
+    private readonly userId: string,
+  ) {}
 
   /** Run Drizzle migrations. Must be called once at startup before any other method. */
   async initialize(): Promise<void> {
@@ -31,31 +34,32 @@ export class TursoEventQueue implements IEventQueue {
         timestamp: event.timestamp,
         deviceId: event.device_id,
         synced: event.synced,
+        userId: this.userId,
       })
       .onConflictDoNothing();
   }
 
   async pendingSync(): Promise<StoredEvent[]> {
-    // Event ids are UUID v7 — lexicographic order equals creation order.
-    // Sorting by id gives deterministic replay even for events created within
-    // the same millisecond (where timestamp alone would be a tie).
     const rows = await this.db
       .select()
       .from(events)
-      .where(eq(events.synced, 0))
+      .where(and(eq(events.synced, 0), eq(events.userId, this.userId)))
       .orderBy(asc(events.id));
     return rows.map(rowToStoredEvent);
   }
 
   async markSynced(ids: string[]): Promise<void> {
     if (ids.length === 0) return;
-    await this.db.update(events).set({ synced: 1 }).where(inArray(events.id, ids));
+    await this.db
+      .update(events)
+      .set({ synced: 1 })
+      .where(and(inArray(events.id, ids), eq(events.userId, this.userId)));
   }
 
   async loadSnapshot(): Promise<{ todos: Todo[]; logs: DailyLog[] }> {
     const [todoRows, logRows] = await Promise.all([
-      this.db.select().from(snapshotTodos),
-      this.db.select().from(snapshotLogs),
+      this.db.select().from(snapshotTodos).where(eq(snapshotTodos.userId, this.userId)),
+      this.db.select().from(snapshotLogs).where(eq(snapshotLogs.userId, this.userId)),
     ]);
     return {
       todos: todoRows.map((row) => JSON.parse(row.data) as Todo),
@@ -70,7 +74,7 @@ export class TursoEventQueue implements IEventQueue {
       if (todos.length > 0) {
         const todoRows = todos.map((todo) => {
           if (!todo.id) throw new Error('Snapshot received a todo with no id — invariant violation');
-          return { notionId: todo.id, data: JSON.stringify(todo), fetchedAt: now };
+          return { notionId: todo.id, data: JSON.stringify(todo), fetchedAt: now, userId: this.userId };
         });
         await tx
           .insert(snapshotTodos)
@@ -82,7 +86,12 @@ export class TursoEventQueue implements IEventQueue {
       }
 
       if (logs.length > 0) {
-        const logRows = logs.map((log) => ({ date: log.date, data: JSON.stringify(log), fetchedAt: now }));
+        const logRows = logs.map((log) => ({
+          date: log.date,
+          data: JSON.stringify(log),
+          fetchedAt: now,
+          userId: this.userId,
+        }));
         await tx
           .insert(snapshotLogs)
           .values(logRows)
@@ -92,19 +101,23 @@ export class TursoEventQueue implements IEventQueue {
           });
       }
 
-      // Prune rows that no longer exist in Notion
+      // Prune rows that no longer exist in Notion — scoped to this user only
       if (todos.length === 0) {
-        await tx.delete(snapshotTodos);
+        await tx.delete(snapshotTodos).where(eq(snapshotTodos.userId, this.userId));
       } else {
         const ids = todos.map((t) => t.id!);
-        await tx.delete(snapshotTodos).where(notInArray(snapshotTodos.notionId, ids));
+        await tx
+          .delete(snapshotTodos)
+          .where(and(eq(snapshotTodos.userId, this.userId), notInArray(snapshotTodos.notionId, ids)));
       }
 
       if (logs.length === 0) {
-        await tx.delete(snapshotLogs);
+        await tx.delete(snapshotLogs).where(eq(snapshotLogs.userId, this.userId));
       } else {
         const dates = logs.map((l) => l.date);
-        await tx.delete(snapshotLogs).where(notInArray(snapshotLogs.date, dates));
+        await tx
+          .delete(snapshotLogs)
+          .where(and(eq(snapshotLogs.userId, this.userId), notInArray(snapshotLogs.date, dates)));
       }
     });
   }
@@ -113,7 +126,7 @@ export class TursoEventQueue implements IEventQueue {
     const now = new Date().toISOString();
     await this.db
       .insert(snapshotLogs)
-      .values({ date: log.date, data: JSON.stringify(log), fetchedAt: now })
+      .values({ date: log.date, data: JSON.stringify(log), fetchedAt: now, userId: this.userId })
       .onConflictDoUpdate({
         target: snapshotLogs.date,
         set: { data: JSON.stringify(log), fetchedAt: now },
@@ -121,7 +134,10 @@ export class TursoEventQueue implements IEventQueue {
   }
 
   async getEntityIdMap(): Promise<EntityIdMap> {
-    const rows = await this.db.select().from(entityIdMap);
+    const rows = await this.db
+      .select()
+      .from(entityIdMap)
+      .where(eq(entityIdMap.userId, this.userId));
     const map = new EntityIdMap();
     for (const row of rows) {
       map.set(row.localId, row.notionId);
@@ -132,7 +148,7 @@ export class TursoEventQueue implements IEventQueue {
   async persistEntityIdMapping(localId: string, notionId: string): Promise<void> {
     await this.db
       .insert(entityIdMap)
-      .values({ localId, notionId })
+      .values({ localId, notionId, userId: this.userId })
       .onConflictDoUpdate({
         target: entityIdMap.localId,
         set: { notionId },
@@ -140,12 +156,16 @@ export class TursoEventQueue implements IEventQueue {
   }
 
   async listCompletedTodayIds(sinceUtc: string): Promise<string[]> {
-    // sinceUtc is start of local today in UTC (e.g. '2026-03-13T07:00:00.000Z' for UTC+7)
-    // No upper bound needed — tasks cannot be marked done in the future
     const rows = await this.db
       .selectDistinct({ entityId: events.entityId })
       .from(events)
-      .where(and(eq(events.eventType, EventType.TodoCompleted), gte(events.timestamp, sinceUtc)));
+      .where(
+        and(
+          eq(events.eventType, EventType.TodoCompleted),
+          gte(events.timestamp, sinceUtc),
+          eq(events.userId, this.userId),
+        )
+      );
     return rows.map((r) => r.entityId);
   }
 
@@ -153,7 +173,7 @@ export class TursoEventQueue implements IEventQueue {
     const rows = await this.db
       .select()
       .from(events)
-      .where(eq(events.entityId, entityId))
+      .where(and(eq(events.entityId, entityId), eq(events.userId, this.userId)))
       .orderBy(asc(events.id));
     return rows.map(rowToStoredEvent);
   }

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -151,7 +151,6 @@ export async function composeForUser(
       config.db.todos.doneKind
     );
     const syncEngine = new SyncEngine(eventQueue, notionLogs, notionTodos);
-    syncEngine.start();
     const logs = new LocalLogsAdapter(eventQueue, projection, syncEngine, deviceId);
     const todos = new LocalTodosAdapter(eventQueue, projection, syncEngine, deviceId);
     const [cachedSnapshot, pendingEvents] = await Promise.all([
@@ -176,6 +175,8 @@ export async function composeForUser(
     const logUseCase = new LogUseCase(logs);
     const todosUseCase = new TodosUseCase(todos);
     const agentUseCase = new AgentUseCase(logs, todos, context, llm, metadataStore, sessionStore);
+    // Start sync after all composition succeeds — prevents orphaned intervals if setup throws
+    syncEngine.start();
     return { logs, todos, logUseCase, todosUseCase, agentUseCase, metadataStore };
   }
 

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -79,9 +79,8 @@ export async function compose(): Promise<Composition> {
   const projection = new LocalProjection();
   const deviceId = getDeviceId();
 
-  // Start the background sync engine
+  // Start the background sync engine (started after setup completes — prevents orphaned intervals)
   const syncEngine = new SyncEngine(eventQueue, notionLogs, notionTodos);
-  syncEngine.start();
 
   // Construct adapters before replaying events — handlers must be registered first
   const logs = new LocalLogsAdapter(eventQueue, projection, syncEngine, deviceId);
@@ -97,6 +96,10 @@ export async function compose(): Promise<Composition> {
   ]);
   projection.loadFromSnapshot(cachedSnapshot);
   projection.applyAll(pendingEvents);
+
+  // Start the background sync engine after all adapters and projection are set up
+  // — prevents orphaned intervals if setup throws
+  syncEngine.start();
 
   // Re-hydrate from Notion in the background — does not block app startup
   hydrateFromNotion(eventQueue, projection, notionLogs, notionTodos).catch((err: unknown) => {

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -19,6 +19,7 @@ import { getOrCreateMetadataDatabaseId } from './config/ensure-metadata-database
 import { SqliteSessionSummaryStore } from './adapters/outbound/local/sqlite-session-summary-store';
 import { TursoEventQueue } from './adapters/outbound/turso/turso-event-queue';
 import { createTursoDb } from './adapters/outbound/turso/client';
+import type { TursoDb } from './adapters/outbound/turso/client';
 import { LocalProjection } from './adapters/outbound/local/local-projection';
 import { LocalLogsAdapter } from './adapters/outbound/local/local-logs-adapter';
 import { LocalTodosAdapter } from './adapters/outbound/local/local-todos-adapter';
@@ -68,7 +69,8 @@ export async function compose(): Promise<Composition> {
   const tursoUrl = settings.TURSO_URL ?? '';
   const tursoToken = settings.TURSO_TOKEN ?? '';
   const db = createTursoDb({ tursoUrl, tursoToken, mode: 'embedded', localDbPath: dbPath });
-  const eventQueue = new TursoEventQueue(db);
+  // TUI runs as the owner on a local device — isolated from web user_id space
+  const eventQueue = new TursoEventQueue(db, '__tui__');
   await eventQueue.initialize();
 
   // Session store stays on a separate local SQLite file — session data is device-local only
@@ -110,5 +112,101 @@ export async function compose(): Promise<Composition> {
       ? new OpenAILLMAdapter(apiKey, settings.OPENAI_MODEL ?? undefined)
       : new StubLLMAdapter();
   const agentUseCase = new AgentUseCase(logs, todos, context, llm, metadataStore, sessionStore);
+  return { logs, todos, logUseCase, todosUseCase, agentUseCase, metadataStore };
+}
+
+/**
+ * Build a Composition scoped to a specific web user.
+ * Owner gets full Notion sync; family members get Turso-only (no Notion).
+ * Called by the web server — migrations must already have run before this.
+ */
+export async function composeForUser(
+  db: TursoDb,
+  userId: string,
+  isOwner: boolean,
+): Promise<Composition> {
+  const eventQueue = new TursoEventQueue(db, userId);
+  const projection = new LocalProjection();
+  const deviceId = getDeviceId();
+
+  if (isOwner) {
+    const { settings } = getResolvedConfig();
+    const metadataDbId = await getOrCreateMetadataDatabaseId(settings);
+    const metadataStore: IMetadataStore =
+      metadataDbId && settings.NOTION_API_KEY
+        ? new NotionMetadataStore(getNotionClient(settings.NOTION_API_KEY), metadataDbId)
+        : new FileMetadataStore();
+    await ensureMetadataBootstrapped(metadataStore, settings);
+    const scope = metadataStore.getAllowedNotionScope();
+    const config =
+      scope?.logsColumns && scope?.todosColumns && scope?.todosDoneKind && settings.NOTION_API_KEY
+        ? buildNotionConfigFromScope(scope, settings.NOTION_API_KEY)
+        : buildNotionConfigFromResolved(settings);
+    const client = getNotionClient(config.apiKey);
+    const notionLogs = new NotionLogsAdapter(client, config.db.logs.databaseId, config.db.logs.columns);
+    const notionTodos = new NotionTodosAdapter(
+      client,
+      config.db.todos.databaseId,
+      config.db.todos.columns,
+      config.db.todos.doneKind
+    );
+    const syncEngine = new SyncEngine(eventQueue, notionLogs, notionTodos);
+    syncEngine.start();
+    const logs = new LocalLogsAdapter(eventQueue, projection, syncEngine, deviceId);
+    const todos = new LocalTodosAdapter(eventQueue, projection, syncEngine, deviceId);
+    const [cachedSnapshot, pendingEvents] = await Promise.all([
+      eventQueue.loadSnapshot(),
+      eventQueue.pendingSync(),
+    ]);
+    projection.loadFromSnapshot(cachedSnapshot);
+    projection.applyAll(pendingEvents);
+    hydrateFromNotion(eventQueue, projection, notionLogs, notionTodos).catch((err: unknown) => {
+      console.error(
+        '[composeForUser/owner] Notion hydration failed:',
+        err instanceof Error ? err.message : String(err)
+      );
+    });
+    const sessionStore = new SqliteSessionSummaryStore(join(getConfigDir(), 'session.db'));
+    const context = new FilesystemContextAdapter();
+    const apiKey = settings.OPENAI_API_KEY;
+    const llm =
+      apiKey && apiKey.length > 0
+        ? new OpenAILLMAdapter(apiKey, settings.OPENAI_MODEL ?? undefined)
+        : new StubLLMAdapter();
+    const logUseCase = new LogUseCase(logs);
+    const todosUseCase = new TodosUseCase(todos);
+    const agentUseCase = new AgentUseCase(logs, todos, context, llm, metadataStore, sessionStore);
+    return { logs, todos, logUseCase, todosUseCase, agentUseCase, metadataStore };
+  }
+
+  // Family member: Turso-only, no Notion sync.
+  // nudge() is a no-op so member events are stored locally but never pushed to Notion.
+  const noopSync = {
+    start: () => {},
+    stop: () => {},
+    nudge: () => {},
+    flush: async () => {},
+  } as unknown as SyncEngine;
+  const logs = new LocalLogsAdapter(eventQueue, projection, noopSync, deviceId);
+  const todos = new LocalTodosAdapter(eventQueue, projection, noopSync, deviceId);
+  const [cachedSnapshot, pendingEvents] = await Promise.all([
+    eventQueue.loadSnapshot(),
+    eventQueue.pendingSync(),
+  ]);
+  projection.loadFromSnapshot(cachedSnapshot);
+  projection.applyAll(pendingEvents);
+  const metadataStore = new FileMetadataStore();
+  const sessionStore = new SqliteSessionSummaryStore(join(getConfigDir(), 'session.db'));
+  const context = new FilesystemContextAdapter();
+  const logUseCase = new LogUseCase(logs);
+  const todosUseCase = new TodosUseCase(todos);
+  const agentUseCase = new AgentUseCase(
+    logs,
+    todos,
+    context,
+    new StubLLMAdapter(),
+    metadataStore,
+    sessionStore
+  );
   return { logs, todos, logUseCase, todosUseCase, agentUseCase, metadataStore };
 }

--- a/src/config/resolved.ts
+++ b/src/config/resolved.ts
@@ -52,6 +52,12 @@ function mergedSettings(): Settings {
     OPENAI_MODEL: process.env.OPENAI_MODEL ?? file.OPENAI_MODEL,
     TURSO_URL: process.env.TURSO_URL ?? file.TURSO_URL,
     TURSO_TOKEN: process.env.TURSO_TOKEN ?? file.TURSO_TOKEN,
+    OWNER_EMAIL: process.env.OWNER_EMAIL ?? file.OWNER_EMAIL,
+    BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET ?? file.BETTER_AUTH_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID ?? file.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET ?? file.GOOGLE_CLIENT_SECRET,
+    LINE_CLIENT_ID: process.env.LINE_CLIENT_ID ?? file.LINE_CLIENT_ID,
+    LINE_CLIENT_SECRET: process.env.LINE_CLIENT_SECRET ?? file.LINE_CLIENT_SECRET,
   };
 }
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -35,6 +35,12 @@ export interface Settings {
   OPENAI_MODEL?: string;
   TURSO_URL?: string;
   TURSO_TOKEN?: string;
+  OWNER_EMAIL?: string;
+  BETTER_AUTH_SECRET?: string;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string;
+  LINE_CLIENT_ID?: string;
+  LINE_CLIENT_SECRET?: string;
 }
 
 const FILENAME = 'settings.json';


### PR DESCRIPTION
## Summary

- **Better Auth schema fix**: Drizzle adapter needs explicit schema keys (`user`, `session`, `account`, `verification`) — without this, the OAuth callback threw on every request
- **Google OAuth button**: was a `<a href>` GET link; switched to `fetch` POST same as LINE, then redirect on response URL
- **callbackURL**: use `window.location.origin` so OAuth redirects back to wherever the client is (5173 in dev, real domain in prod)
- **Service worker**: added `navigateFallbackDenylist: [/^\/api\//]` — SW was intercepting the OAuth callback navigation and serving cached `index.html` instead of letting Bun handle it
- **Elysia migration**: replaced raw `Bun.serve()` with Elysia; auth middleware uses `guard` (beforeHandle) + `resolve` pattern — `resolve` runs after `beforeHandle` so session is guaranteed valid when composition is fetched

## Test plan

- [x] `GET /api/todos` unauthenticated → 401
- [x] `GET /api/auth/get-session` → 200 null (no session)
- [x] Google login → redirects to Google → redirects back to FE origin → session active
- [x] LINE login → redirects to LINE → redirects back to FE origin → session active
- [x] SPA routes (e.g. `/dashboard`) → 200 index.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in (Google & LINE) with a user-facing login page and session handling.
  * Invitation-based access control and per-user compositions (owner vs family-member flows).

* **Chores**
  * Server and database migrations to add auth-related tables and user-scoped data.
  * Routing adjusted for authenticated flows; client session hook and UI button components added.
  * Config and dependency updates to support the new auth stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->